### PR TITLE
Add white background-color to demo-navigation

### DIFF
--- a/demo-navigation.html
+++ b/demo-navigation.html
@@ -35,6 +35,7 @@ Then, just include the component in each demo page.
                   0 3px 1px -2px rgba(0, 0, 0, 0.2);
       padding: 8px 20px 8px 20px;
       text-transform: uppercase;
+      background-color: white;
     }
     nav > ul {
       padding: 0;


### PR DESCRIPTION
Noticed here: https://cdn.vaadin.com/vaadin-core-elements/master/vaadin-date-picker/demo/ that background-color is missing.