### PR TITLE
Increase body line-height for demo pages

### DIFF
--- a/common.html
+++ b/common.html
@@ -3,6 +3,7 @@
     body {
       font-family: 'Roboto', 'Noto', sans-serif;
       font-size: 14px;
+      line-height: 1.5;
       margin: 0;
       padding: 24px;
       background-color: #fafafa;


### PR DESCRIPTION
The default line height is too small. The lines of text are too tightly placed together.

Increasing the line height allows for easier reading and makes a better visual impression.

### Before vs After
![screen shot 2017-05-30 at 08 50 29](https://cloud.githubusercontent.com/assets/247998/26569802/8d1187b4-4515-11e7-9ec8-0548c8ae2192.png) ![screen shot 2017-05-30 at 08 50 50](https://cloud.githubusercontent.com/assets/247998/26569807/91e4a1c2-4515-11e7-9a80-19a00b99a14c.png)
