### PR TITLE
Change order of extractSource and _demoRenderer init

### DIFF
--- a/nice-demo-snippet.html
+++ b/nice-demo-snippet.html
@@ -305,13 +305,13 @@ allowing easy styling and scripting in the parent (document) scope.
         connectedCallback() {
           super.connectedCallback();
 
+          this._extractSource();
+
           if (!this._demoRenderer) {
             const demoRenderer = document.createElement('div');
             this.appendChild(demoRenderer);
             this._demoRenderer = demoRenderer;
           }
-
-          this._extractSource();
         }
 
         disconnectedCallback() {


### PR DESCRIPTION
Fixes the issue with vaadin-grid column groups causing all the header rows to not have a proper style scope on Firefox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/elements-demo-resources/19)
<!-- Reviewable:end -->
